### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 
 A simple template for creating custom tools for Cursor IDE using Model Context Protocol (MCP). Create your own repository from this template, modify the tools, and connect them to your Cursor IDE.
 
+<a href="https://glama.ai/mcp/servers/iwyh0e7za6">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/iwyh0e7za6/badge" alt="Weaviate Server MCP server" />
+</a>
+
 ## Quick Start
 
 1. Click "Deploy to Heroku" button


### PR DESCRIPTION
This PR adds a badge for the [Weaviate MCP Server](https://glama.ai/mcp/servers/iwyh0e7za6) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/iwyh0e7za6">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/iwyh0e7za6/badge" alt="Weaviate Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.